### PR TITLE
Fix bitrot

### DIFF
--- a/DigitalOcean.cabal
+++ b/DigitalOcean.cabal
@@ -24,7 +24,7 @@ library
                        Net.DigitalOcean.Request
   default-extensions:  OverloadedStrings, TemplateHaskell, DeriveGeneric
   ghc-options:         -Wall
-  build-depends:       base >=4.7 && <4.8,
+  build-depends:       base >=4.7 && <4.9,
                        text >= 1.2.0.3 && < 1.3,
                        -- Transative dependencies I don't want to constrain
                        lens, wreq, aeson, containers, mtl,

--- a/src/Net/DigitalOcean/Images.hs
+++ b/src/Net/DigitalOcean/Images.hs
@@ -54,12 +54,6 @@ instance FromJSON Image where
   parseJSON _ = fail "image must be object"
 
 
-instance FromJSON (Maybe Image) where
-  parseJSON xs@(Object x)
-    | HM.null x = return Nothing
-    | otherwise = fmap Just . parseJSON $ xs
-  parseJSON _ = return Nothing
-
 imagesEndpoint :: String
 imagesEndpoint = "/v2/images/"
 

--- a/src/Net/DigitalOcean/Regions.hs
+++ b/src/Net/DigitalOcean/Regions.hs
@@ -37,12 +37,6 @@ instance FromJSON Region where
                          x .: "available"
   parseJSON _ = fail "region must be object"
 
-instance FromJSON (Maybe Region) where
-  parseJSON xs@(Object x)
-    | HM.null x = return Nothing
-    | otherwise = fmap Just . parseJSON $ xs
-  parseJSON _ = return Nothing
-
 -- | Returns a list of all the visible Digital Ocean regions
 --
 -- <https://developers.digitalocean.com/#list-all-regions DO documentation>


### PR DESCRIPTION
- Incremented upper bound of `base` so that library will build with `ghc 7.10.3`
- Removed Overlapping instances so that library will build with recent `aeson`. (Tested with `aeson-0.11.2.0`)
